### PR TITLE
Supports https links, and adds option to disable regex restriction on hosts

### DIFF
--- a/lib/unshorten.rb
+++ b/lib/unshorten.rb
@@ -1,4 +1,5 @@
 require 'net/http'
+require 'net/https'
 require 'uri'
 
 # Get original URLs from shortened ones.
@@ -28,7 +29,8 @@ class Unshorten
     # @option options [Integer] :timeout Timeout in seconds, for every request
     # @option options [Regexp]  :short_hosts Hosts that provides short url
     #                                        services, only send requests if
-    #                                        host matches this regexp
+    #                                        host matches this regexp. Set to false
+    #                                        to follow all redirects.
     # @option options [Boolean] :use_cache Use cached result if available
     # @option options [Boolean] :add_missing_http add 'http://' if missing
     # @see DEFAULT_OPTIONS
@@ -70,10 +72,12 @@ class Unshorten
 
       uri = URI.parse(url) rescue nil
 
-      return url if uri.nil? or not uri.host =~ options[:short_hosts]
+      return url if uri.nil?
+      return url if options[:short_hosts] != false and not uri.host =~ options[:short_hosts]
 
       http = Net::HTTP.new(uri.host, uri.port)
       http.read_timeout = options[:timeout]
+      http.use_ssl = true if uri.scheme == "https"
 
       response = http.request_head(uri.path.empty? ? '/' : uri.path) rescue nil
 

--- a/test/test_unshorten.rb
+++ b/test/test_unshorten.rb
@@ -24,4 +24,19 @@ class UnshortenTest < Test::Unit::TestCase
         assert_equal SHORTENED_URL, Unshorten.unshorten(SHORTENED_URL, :short_hosts => /jmp/, :use_cache => false)
     end
 
+    HTTPS_LINK_1_FULL = 'https://github.com/aaronpk/unshorten'
+    HTTPS_LINK_1_SHORT = 'https://t.co/5204FqAr'
+
+    def test_https_link
+        assert_equal HTTPS_LINK_1_FULL, Unshorten.unshorten(HTTPS_LINK_1_SHORT, :short_hosts => /./, :use_cache => false)
+    end
+
+    def test_follow_all_redirects
+        assert_equal HTTPS_LINK_1_FULL, Unshorten.unshorten(HTTPS_LINK_1_SHORT, :short_hosts => false, :use_cache => false)
+    end
+
+    def test_only_tco_links
+        assert_equal "http://aaron.pk/649", Unshorten.unshorten(HTTPS_LINK_1_SHORT, :short_hosts => /t\.co/, :use_cache => false)
+    end
+
 end


### PR DESCRIPTION
Adds support for following https URLs. Adds `:short_hosts => false` option to disable pattern matching restriction on URL hosts.
