### PR TITLE
Set open_timeout as well as read_timeout

### DIFF
--- a/lib/unshorten.rb
+++ b/lib/unshorten.rb
@@ -76,6 +76,7 @@ class Unshorten
       return url if options[:short_hosts] != false and not uri.host =~ options[:short_hosts]
 
       http = Net::HTTP.new(uri.host, uri.port)
+      http.open_timeout = options[:timeout]
       http.read_timeout = options[:timeout]
       http.use_ssl = true if uri.scheme == "https"
 


### PR DESCRIPTION
Currently unshorten doesn't set open_timeout, which can lead to long pauses in my app. Perhaps there is some reason why you haven't set this already? 
