### PR TITLE
Bump to 0.3.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    unshorten (0.3.3)
+    unshorten (0.3.4)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module Unshorten
-  VERSION = '0.3.3'
+  VERSION = '0.3.4'
 end

--- a/unshorten.gemspec
+++ b/unshorten.gemspec
@@ -6,7 +6,6 @@ Gem::Specification.new do |s|
   s.name = 'unshorten'
   s.version = Unshorten::VERSION
   s.license = 'BSD'
-  s.date = Date.civil(2015, 9, 5)
   s.summary = 'Unshorten URLs'
   s.description = 'Get original URLs from shortened ones'
   s.authors = ["Jun Wu"]


### PR DESCRIPTION
* Bumping up the official gem release version.
* Also dropping 'date' property from gemspec - defaults to current date anyway, otherwise requires `date` library to be added now or throws errors.